### PR TITLE
Removing usage of deprecated `set-output` method

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,8 +3,8 @@ import sys
 
 
 def set_action_output(name: str, value: str):
-    sys.stdout.write(f'::set-output name={name}::{value}\n')
-
+    with open(os.environ["GITHUB_OUTPUT"], "a") as myfile:
+        myfile.write(f"{name}={value}\n")
 
 def main():
     path = os.environ["INPUT_PATH"]


### PR DESCRIPTION
As per [this](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) blog post from Github, set-output command is deprecated and will get removed soon.